### PR TITLE
Install tzdata

### DIFF
--- a/x86_64/Dockerfile
+++ b/x86_64/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:16.04
 MAINTAINER Jonne Haß <me@jhass.eu>
 
 RUN apt-get update && \
-apt-get install -y apt-transport-https curl build-essential pkg-config libssl-dev llvm libedit-dev libgmp-dev libxml2-dev libyaml-dev libreadline-dev git-core && \
+apt-get install -y apt-transport-https tzdata curl build-essential pkg-config libssl-dev llvm libedit-dev libgmp-dev libxml2-dev libyaml-dev libreadline-dev git-core && \
 curl https://dist.crystal-lang.org/apt/setup.sh | bash && \
 apt-get update && \
 apt-get install -y --allow-unauthenticated crystal


### PR DESCRIPTION
This will allow fixing CI issues with crystal 0.22.0

Before this change:

```
root@c7d51ccb75b4:/mnt# tzselect 
/usr/bin/tzselect: line 180: /usr/share/zoneinfo/iso3166.tab: No such file or directory
/usr/bin/tzselect: time zone files are not set up correctly
```

After this change:

```
root@3f59dce19d2b:/mnt# tzselect 
Please identify a location so that time zone rules can be set correctly.
Please select a continent, ocean, "coord", or "TZ".
 1) Africa
 2) Americas
 3) Antarctica
...
```

If an updated version for 0.22.0 can be published when you have time, the CI will be happy again.